### PR TITLE
Update settingsdialog.ui -- fixed typo

### DIFF
--- a/src/ui/settingsdialog.ui
+++ b/src/ui/settingsdialog.ui
@@ -120,7 +120,7 @@
            <item>
             <widget class="QLabel" name="label_7">
              <property name="text">
-              <string>Morrowing</string>
+              <string>Morrowind</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Small typo in the Deployers tab in Settings.