### PR TITLE
Fix executable name in desktop shortcut

### DIFF
--- a/install_files/limo.desktop
+++ b/install_files/limo.desktop
@@ -6,5 +6,5 @@ Name=Limo
 Categories=Utility;FileTools;
 Icon=limo
 MimeType=x-scheme-handler/nxm;
-Exec=limo %u
+Exec=Limo %u
 Terminal=false


### PR DESCRIPTION
The desktop shortcut had the improper name (limo vs Limo). This should fix the issue