### PR TITLE
fix default appdialog command_field text for flatpak steam by using xdg-open

### DIFF
--- a/src/ui/addappdialog.cpp
+++ b/src/ui/addappdialog.cpp
@@ -380,7 +380,7 @@ void AddAppDialog::onApplicationImported(QString name,
                                          QString icon_path)
 {
   ui->name_field->setText(name);
-  ui->command_field->setText("steam -applaunch " + app_id);
+  ui->command_field->setText("xdg-open steam://rungameid/" + app_id);
   app_id_ = app_id.toInt();
   steam_install_path_ = install_dir;
   steam_prefix_path_ = prefix_path;


### PR DESCRIPTION
This change changes the setText for new apps imported from steam to launch with the xdg-open steam://rungameid/$appid command instead of calling steam directly. This allows you to use the same command for flatpak steam as well as native steam.