### PR TITLE
Add mod support config for Stardew Valley

### DIFF
--- a/steam_app_configs/413150.json
+++ b/steam_app_configs/413150.json
@@ -1,0 +1,12 @@
+{
+	"deployers" : 
+	[
+		{
+			"deploy_mode" : "hard_link",
+			"name" : "Install",
+			"target_dir" : "$STEAM_INSTALL_PATH$/Mods/",
+			"type" : "Case Matching Deployer"
+		}
+	],
+	"name" : "Stardew Valley"
+}


### PR DESCRIPTION
I have free time now, so I'm adding mod support configs for games I currently play. 

This is for Stardew Valley, there are more coming, next is OpenMW Morrowind.

Edit: I have encountered "quirks" when trying to mod Stardew Valley with Simple Deployer. When I deploy there, the deployed mods are not showing there, so instead I settled on Case Matching Deployer and it deploys without a problem.