### PR TITLE
Integrate tests with ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,3 +379,8 @@ else()
     install(FILES install_files/changelogs.json
             DESTINATION ${LIMO_INSTALL_PREFIX}/share/limo)
 endif()
+
+if (BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,9 +81,8 @@ pkg_check_modules(ZSTD REQUIRED libzstd)
 # zlib
 find_package(ZLIB REQUIRED)
 
-
-set(PROJECT_SOURCES
-        resources/icons.qrc
+# Separated for tests
+set(CORE_SOURCES
         src/core/addmodinfo.h
         src/core/appinfo.h
         src/core/autotag.cpp
@@ -176,6 +175,32 @@ set(PROJECT_SOURCES
         src/core/tool.h
         src/core/versionchangelog.cpp
         src/core/versionchangelog.h
+)
+
+add_library(core OBJECT ${CORE_SOURCES})
+target_include_directories(core
+    PRIVATE ${PROJECT_SOURCE_DIR}/src
+    PUBLIC ${LibArchive_INCLUDE_DIRS}
+    PUBLIC ${LIBLOOT_INCLUDE_DIR}
+    PUBLIC ${JSONCPP_INCLUDE_DIRS}
+    PUBLIC ${LIBUNRAR_INCLUDE_DIR}
+    PUBLIC ${LZ4_INCLUDE_DIRS}
+    PUBLIC ${ZSTD_INCLUDE_DIRS})
+
+target_link_libraries(core
+    PUBLIC ${JSONCPP_LIBRARIES}
+    PUBLIC ${LibArchive_LIBRARIES}
+    PUBLIC ${LIBLOOT_PATH}
+    PUBLIC cpr::cpr
+    PUBLIC OpenSSL::SSL
+    PUBLIC ${LIBUNRAR_PATH}
+    PUBLIC ${LZ4_LIBRARIES}
+    PUBLIC ${ZSTD_LIBRARIES}
+    PUBLIC pugixml::pugixml
+    PUBLIC ZLIB::ZLIB)
+
+set(PROJECT_SOURCES
+        resources/icons.qrc
         src/main.cpp
         src/ui/addapikeydialog.cpp
         src/ui/addapikeydialog.h
@@ -322,29 +347,13 @@ configure_file(src/core/consts.h.in
 add_executable(Limo
     ${PROJECT_SOURCES})
 
-target_include_directories(Limo
-    PRIVATE ${PROJECT_SOURCE_DIR}/src
-    PRIVATE ${LibArchive_INCLUDE_DIRS}
-    PRIVATE ${LIBLOOT_INCLUDE_DIR}
-    PRIVATE ${JSONCPP_INCLUDE_DIRS}
-    PRIVATE ${LIBUNRAR_INCLUDE_DIR}
-    PRIVATE ${LZ4_INCLUDE_DIRS}
-    PRIVATE ${ZSTD_INCLUDE_DIRS})
+target_include_directories(Limo PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
 target_link_libraries(Limo
+    PRIVATE core
     PRIVATE Qt${QT_VERSION_MAJOR}::Widgets
-    PRIVATE ${JSONCPP_LIBRARIES}
-    PRIVATE ${LibArchive_LIBRARIES}
-    PRIVATE ${LIBLOOT_PATH}
     PRIVATE Qt${QT_VERSION_MAJOR}::Svg
-    PRIVATE cpr::cpr
-    PRIVATE OpenSSL::SSL
-    PRIVATE Qt${QT_VERSION_MAJOR}::Network
-    PRIVATE ${LIBUNRAR_PATH}
-    PRIVATE ${LZ4_LIBRARIES}
-    PRIVATE ${ZSTD_LIBRARIES}
-    PRIVATE pugixml::pugixml
-    PRIVATE ZLIB::ZLIB)
+    PRIVATE Qt${QT_VERSION_MAJOR}::Network)
 
 install(PROGRAMS ${CMAKE_BINARY_DIR}/Limo
     DESTINATION bin RENAME limo)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ cmake --build build
 ```
 cmake -DCMAKE_BUILD_TYPE=Release -S . -B build -DBUILD_TESTING=ON
 cmake --build build
-build/tests/tests
+ctest --test-dir build
 ```
 
 #### (Optional) Build the documentation:

--- a/README.md
+++ b/README.md
@@ -127,10 +127,9 @@ cmake --build build
 #### (Optional) Run the tests:
 
 ```
-mkdir tests/build
-cmake -DCMAKE_BUILD_TYPE=Release -S tests -B tests/build
-cmake --build tests/build
-tests/build/tests
+cmake -DCMAKE_BUILD_TYPE=Release -S . -B build -DBUILD_TESTING=ON
+cmake --build build
+build/tests/tests
 ```
 
 #### (Optional) Build the documentation:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,91 +2,6 @@
 find_package(Catch2 3 REQUIRED)
 
 set(TEST_SOURCES
-        ../src/core/addmodinfo.h
-        ../src/core/appinfo.h
-        ../src/core/autotag.cpp
-        ../src/core/autotag.h
-        ../src/core/backupmanager.cpp
-        ../src/core/backupmanager.h
-        ../src/core/backuptarget.cpp
-        ../src/core/backuptarget.h
-        ../src/core/bg3deployer.cpp
-        ../src/core/bg3deployer.h
-        ../src/core/bg3pakfile.cpp
-        ../src/core/bg3pakfile.h
-        ../src/core/bg3plugin.cpp
-        ../src/core/bg3plugin.h
-        ../src/core/casematchingdeployer.cpp
-        ../src/core/casematchingdeployer.h
-        ../src/core/conflictinfo.h
-        ../src/core/cryptography.cpp
-        ../src/core/cryptography.h
-        ../src/core/deployer.cpp
-        ../src/core/deployer.h
-        ../src/core/deployerfactory.cpp
-        ../src/core/deployerfactory.h
-        ../src/core/deployerinfo.h
-        ../src/core/editapplicationinfo.h
-        ../src/core/editautotagaction.cpp
-        ../src/core/editautotagaction.h
-        ../src/core/editdeployerinfo.h
-        ../src/core/editmanualtagaction.cpp
-        ../src/core/editmanualtagaction.h
-        ../src/core/editprofileinfo.h
-        ../src/core/filechangechoices.h
-        ../src/core/fomod/dependency.cpp
-        ../src/core/fomod/dependency.h
-        ../src/core/fomod/file.h
-        ../src/core/fomod/fomodinstaller.cpp
-        ../src/core/fomod/fomodinstaller.h
-        ../src/core/fomod/plugin.h
-        ../src/core/fomod/plugindependency.h
-        ../src/core/fomod/plugingroup.h
-        ../src/core/fomod/plugintype.h
-        ../src/core/importmodinfo.h
-        ../src/core/installer.cpp
-        ../src/core/installer.h
-        ../src/core/log.cpp
-        ../src/core/log.h
-        ../src/core/lootdeployer.cpp
-        ../src/core/lootdeployer.h
-        ../src/core/lspakextractor.cpp
-        ../src/core/lspakextractor.h
-        ../src/core/lspakfilelistentry.h
-        ../src/core/lspakheader.h
-        ../src/core/manualtag.cpp
-        ../src/core/manualtag.h
-        ../src/core/mod.cpp
-        ../src/core/mod.h
-        ../src/core/moddedapplication.cpp
-        ../src/core/moddedapplication.h
-        ../src/core/modinfo.h
-        ../src/core/nexus/api.cpp
-        ../src/core/nexus/api.h
-        ../src/core/nexus/file.cpp
-        ../src/core/nexus/file.h
-        ../src/core/nexus/mod.cpp
-        ../src/core/nexus/mod.h
-        ../src/core/openmwarchivedeployer.cpp
-        ../src/core/openmwarchivedeployer.h
-        ../src/core/openmwplugindeployer.cpp
-        ../src/core/openmwplugindeployer.h
-        ../src/core/parseerror.h
-        ../src/core/pathutils.cpp
-        ../src/core/pathutils.h
-        ../src/core/plugindeployer.cpp
-        ../src/core/plugindeployer.h
-        ../src/core/progressnode.cpp
-        ../src/core/progressnode.h
-        ../src/core/reversedeployer.cpp
-        ../src/core/reversedeployer.h
-        ../src/core/tag.cpp
-        ../src/core/tag.h
-        ../src/core/tagcondition.h
-        ../src/core/tagconditionnode.cpp
-        ../src/core/tagconditionnode.h
-        ../src/core/tool.cpp
-        ../src/core/tool.h
         test_backupmanager.cpp
         test_bg3deployer.cpp
         test_cryptography.cpp
@@ -103,30 +18,17 @@ set(TEST_SOURCES
         test_utils.h
         tests.cpp
 )
-     
+
 configure_file(test_utils.h.in test_utils.h)
-     
+
 add_executable(tests ${TEST_SOURCES})
 target_include_directories(tests
-        PUBLIC "${PROJECT_BINARY_DIR}"
-        PRIVATE ${LibArchive_INCLUDE_DIRS}
-        PRIVATE ${LIBLOOT_INCLUDE_DIR}
-        PRIVATE ${JSONCPP_INCLUDE_DIRS}
-        PRIVATE ${LIBUNRAR_INCLUDE_DIR}
-        PRIVATE ${LZ4_INCLUDE_DIRS}
-        PRIVATE ${ZSTD_INCLUDE_DIRS})
+    PRIVATE core
+)
 target_link_libraries(tests
-PRIVATE Catch2::Catch2WithMain
-    PRIVATE ${JSONCPP_LIBRARIES}
-    PRIVATE ${LibArchive_LIBRARIES}
-    PRIVATE ${LIBLOOT_PATH}
-    PRIVATE cpr::cpr
-    PRIVATE OpenSSL::SSL
-    PRIVATE ${LIBUNRAR_PATH}
-    PRIVATE ${LZ4_LIBRARIES}
-    PRIVATE ${ZSTD_LIBRARIES}
-    PRIVATE ZLIB::ZLIB
-    PRIVATE pugixml::pugixml)
+    PRIVATE Catch2::Catch2WithMain
+    PRIVATE core
+)
 
 include(Catch)
 catch_discover_tests(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -127,3 +127,6 @@ PRIVATE Catch2::Catch2WithMain
     PRIVATE ${ZSTD_LIBRARIES}
     PRIVATE ZLIB::ZLIB
     PRIVATE pugixml::pugixml)
+
+include(Catch)
+catch_discover_tests(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,89 +1,5 @@
-cmake_minimum_required(VERSION 3.25)
-project(LMM_Tests LANGUAGES CXX)
-
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_BUILD_TYPE RelWithDebInfo)
-
-option(USE_SYSTEM_LIBUNRAR "Whether to use the system version of libunrar." ON)
-   
-# libarchive
-find_package(LibArchive REQUIRED)
-
-# jsoncpp
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(JSONCPP jsoncpp)
-
-# pugixml
-find_package(pugixml REQUIRED)
-
 # catch2
 find_package(Catch2 3 REQUIRED)
-
-# cpr
-find_package(cpr REQUIRED)
-
-# OpenSSL
-find_package(OpenSSL REQUIRED)
-
-# libunrar
-if(NOT DEFINED LIBUNRAR_INCLUDE_DIR)
-    if(IS_FLATPAK)
-        set(LIBUNRAR_INCLUDE_DIR "/app/include/unrar")
-    else()
-        if(USE_SYSTEM_LIBUNRAR)
-            find_file(LIBUNRAR_DLL_PATH "unrar/dll.hpp" REQUIRED)
-            cmake_path(GET LIBUNRAR_DLL_PATH PARENT_PATH LIBUNRAR_INCLUDE_DIR)
-        else()
-            set(LIBUNRAR_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/unrar")
-        endif()
-    endif()
-endif()
-if(NOT DEFINED LIBUNRAR_PATH)
-    if(IS_FLATPAK)
-        set(LIBUNRAR_PATH "/app/lib/libunrar.a")
-    else()
-        if(USE_SYSTEM_LIBUNRAR)
-            find_library(LIBUNRAR_PATH libunrar.a)
-            if(${LIBUNRAR_PATH} STREQUAL "LIBUNRAR_PATH-NOTFOUND")
-                find_library(LIBUNRAR_PATH libunrar.so REQUIRED)
-            endif()
-        else()
-            set(LIBUNRAR_PATH "${PROJECT_SOURCE_DIR}/unrar/libunrar.a")
-        endif()
-    endif()
-endif()
-
-# libloot
-if(NOT DEFINED LIBLOOT_INCLUDE_DIR)
-    find_file(LIBLOOT_API_PATH "loot/api.h" REQUIRED)
-    cmake_path(GET LIBLOOT_API_PATH PARENT_PATH LIBLOOT_INCLUDE_DIR)
-endif()
-if(NOT DEFINED LIBLOOT_PATH)
-    find_library(LIBLOOT_PATH libloot.so REQUIRED)
-endif()
-
-# lz4
-if(NOT DEFINED LZ4_INCLUDE_DIR)
-    find_file(LZ4_HEADER_PATH "lz4.h" REQUIRED)
-    cmake_path(GET LZ4_HEADER_PATH PARENT_PATH LZ4_INCLUDE_DIR)
-endif()
-if(NOT DEFINED LZ4_PATH)
-    find_library(LZ4_PATH liblz4.so REQUIRED)
-endif()
-
-# zstd
-if(NOT DEFINED ZSTD_INCLUDE_DIR)
-    find_file(ZSTD_HEADER_PATH "zstd.h" REQUIRED)
-    cmake_path(GET ZSTD_HEADER_PATH PARENT_PATH ZSTD_INCLUDE_DIR)
-endif()
-if(NOT DEFINED ZSTD_PATH)
-    find_library(ZSTD_PATH libzstd.a REQUIRED)
-endif()
-
-# zlib
-find_package(ZLIB REQUIRED)
-
 
 set(TEST_SOURCES
         ../src/core/addmodinfo.h
@@ -197,8 +113,8 @@ target_include_directories(tests
         PRIVATE ${LIBLOOT_INCLUDE_DIR}
         PRIVATE ${JSONCPP_INCLUDE_DIRS}
         PRIVATE ${LIBUNRAR_INCLUDE_DIR}
-        PRIVATE ${LZ4_INCLUDE_DIR}
-        PRIVATE ${ZSTD_INCLUDE_DIR})
+        PRIVATE ${LZ4_INCLUDE_DIRS}
+        PRIVATE ${ZSTD_INCLUDE_DIRS})
 target_link_libraries(tests
 PRIVATE Catch2::Catch2WithMain
     PRIVATE ${JSONCPP_LIBRARIES}
@@ -207,7 +123,7 @@ PRIVATE Catch2::Catch2WithMain
     PRIVATE cpr::cpr
     PRIVATE OpenSSL::SSL
     PRIVATE ${LIBUNRAR_PATH}
-    PRIVATE ${LZ4_PATH}
-    PRIVATE ${ZSTD_PATH}
+    PRIVATE ${LZ4_LIBRARIES}
+    PRIVATE ${ZSTD_LIBRARIES}
     PRIVATE ZLIB::ZLIB
     PRIVATE pugixml::pugixml)

--- a/tests/test_backupmanager.cpp
+++ b/tests/test_backupmanager.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 
 
-TEST_CASE("Backups are created", "[.backup]")
+TEST_CASE("Backups are created", "[backup]")
 {
   resetAppDir();
   BackupManager bak_man;
@@ -25,7 +25,7 @@ TEST_CASE("Backups are created", "[.backup]")
   verifyDirsAreEqual(DATA_DIR / "app" / "a", DATA_DIR / "app" / "a.4.lmmbakman", true);
 }
 
-TEST_CASE("Backups are activated", "[.backup]")
+TEST_CASE("Backups are activated", "[backup]")
 {
   resetAppDir();
   BackupManager bak_man;
@@ -58,7 +58,7 @@ TEST_CASE("Backups are activated", "[.backup]")
     DATA_DIR / "target" / "bak_man" / "change_bak" / "a", DATA_DIR / "app" / "a.1.lmmbakman", true);
 }
 
-TEST_CASE("Backups are removed", "[.backup]")
+TEST_CASE("Backups are removed", "[backup]")
 {
   resetAppDir();
   BackupManager bak_man;
@@ -78,7 +78,7 @@ TEST_CASE("Backups are removed", "[.backup]")
   verifyDirsAreEqual(DATA_DIR / "app", DATA_DIR / "target" / "bak_man" / "remove_bak_2");
 }
 
-TEST_CASE("Profiles are working", "[.backup]")
+TEST_CASE("Profiles are working", "[backup]")
 {
   resetAppDir();
   BackupManager bak_man;
@@ -118,7 +118,7 @@ TEST_CASE("Profiles are working", "[.backup]")
                       DATA_DIR / "target" / "bak_man" / "profiles_1" / "a-Fil _3");
 }
 
-TEST_CASE("State is saved", "[.backup]")
+TEST_CASE("State is saved", "[backup]")
 {
   resetAppDir();
   BackupManager bak_man;
@@ -154,7 +154,7 @@ TEST_CASE("State is saved", "[.backup]")
                       DATA_DIR / "target" / "bak_man" / "profiles_0" / "a-Fil _3");
 }
 
-TEST_CASE("Invalid state is repaired", "[.backup]")
+TEST_CASE("Invalid state is repaired", "[backup]")
 {
   resetAppDir();
   BackupManager bak_man;
@@ -174,7 +174,7 @@ TEST_CASE("Invalid state is repaired", "[.backup]")
   verifyDirsAreEqual(DATA_DIR / "app", DATA_DIR / "target" / "bak_man" / "invalid_state");
 }
 
-TEST_CASE("Targets are removed", "[.backup]")
+TEST_CASE("Targets are removed", "[backup]")
 {
   resetAppDir();
   BackupManager bak_man;
@@ -192,7 +192,7 @@ TEST_CASE("Targets are removed", "[.backup]")
   verifyDirsAreEqual(DATA_DIR / "app", DATA_DIR / "source" / "app", true);
 }
 
-TEST_CASE("Backups are overwritten", "[.backup]")
+TEST_CASE("Backups are overwritten", "[backup]")
 {
   resetAppDir();
   BackupManager bak_man;

--- a/tests/test_bg3deployer.cpp
+++ b/tests/test_bg3deployer.cpp
@@ -17,7 +17,7 @@ void resetBg3Files()
   sfs::copy(source, target);
 }
 
-TEST_CASE("Plugins are found", "[.bg3]")
+TEST_CASE("Plugins are found", "[bg3]")
 {
   resetBg3Files();
   
@@ -39,7 +39,7 @@ TEST_CASE("Plugins are found", "[.bg3]")
                       DATA_DIR / "target" / "bg3" / "1" / "modsettings.lsx");
 }
 
-TEST_CASE("Loadorder can be modified", "[.bg3]")
+TEST_CASE("Loadorder can be modified", "[bg3]")
 {
   resetBg3Files();
   
@@ -63,7 +63,7 @@ TEST_CASE("Loadorder can be modified", "[.bg3]")
   REQUIRE_THAT(depl.getModNames(), Catch::Matchers::Equals(depl_2.getModNames()));
 }
 
-TEST_CASE("Profiles are managed", "[.bg3]")
+TEST_CASE("Profiles are managed", "[bg3]")
 {
   resetBg3Files();
   

--- a/tests/test_cryptography.cpp
+++ b/tests/test_cryptography.cpp
@@ -16,7 +16,7 @@ std::string generateRandomString(std::default_random_engine& e)
   return str;
 }
 
-TEST_CASE("String are encrypted", "[.crypto]")
+TEST_CASE("String are encrypted", "[crypto]")
 {
   std::random_device r;
   std::default_random_engine e(r());

--- a/tests/test_deployer.cpp
+++ b/tests/test_deployer.cpp
@@ -8,7 +8,7 @@
 #include <ranges>
 
 
-TEST_CASE("Mods are added and removed", "[.deployer]")
+TEST_CASE("Mods are added and removed", "[deployer]")
 {
   Deployer depl = Deployer(DATA_DIR / "source", DATA_DIR / "app", "");
   depl.addProfile();
@@ -18,7 +18,7 @@ TEST_CASE("Mods are added and removed", "[.deployer]")
   REQUIRE(depl.getNumMods() == 0);
 }
 
-TEST_CASE("Mods are being deployed", "[.deployer]")
+TEST_CASE("Mods are being deployed", "[deployer]")
 {
   resetAppDir();
   Deployer depl = Deployer(DATA_DIR / "source", DATA_DIR / "app", "");
@@ -28,7 +28,7 @@ TEST_CASE("Mods are being deployed", "[.deployer]")
   verifyDirsAreEqual(DATA_DIR / "app", DATA_DIR / "target" / "mod1", true);
 }
 
-TEST_CASE("Mod status works", "[.deployer]")
+TEST_CASE("Mod status works", "[deployer]")
 {
   resetAppDir();
   Deployer depl = Deployer(DATA_DIR / "source", DATA_DIR / "app", "");
@@ -41,7 +41,7 @@ TEST_CASE("Mod status works", "[.deployer]")
   verifyDirsAreEqual(DATA_DIR / "app", DATA_DIR / "target" / "mod1", true);
 }
 
-TEST_CASE("Deployed mods are removed", "[.deployer]")
+TEST_CASE("Deployed mods are removed", "[deployer]")
 {
   resetAppDir();
   Deployer depl = Deployer(DATA_DIR / "source", DATA_DIR / "app", "");
@@ -53,7 +53,7 @@ TEST_CASE("Deployed mods are removed", "[.deployer]")
   verifyDirsAreEqual(DATA_DIR / "app", DATA_DIR / "source" / "app", true);
 }
 
-TEST_CASE("Conflicts are resolved", "[.deployer]")
+TEST_CASE("Conflicts are resolved", "[deployer]")
 {
   resetAppDir();
   Deployer depl = Deployer(DATA_DIR / "source", DATA_DIR / "app", "");
@@ -65,7 +65,7 @@ TEST_CASE("Conflicts are resolved", "[.deployer]")
   verifyDirsAreEqual(DATA_DIR / "app", DATA_DIR / "target" / "mod012", true);
 }
 
-TEST_CASE("Files are restored", "[.deployer]")
+TEST_CASE("Files are restored", "[deployer]")
 {
   resetAppDir();
   Deployer depl = Deployer(DATA_DIR / "source", DATA_DIR / "app", "");
@@ -81,7 +81,7 @@ TEST_CASE("Files are restored", "[.deployer]")
   verifyDirsAreEqual(DATA_DIR / "app", DATA_DIR / "source" / "app", true);
 }
 
-TEST_CASE("Loadorder is being changed", "[.deployer]")
+TEST_CASE("Loadorder is being changed", "[deployer]")
 {
   resetAppDir();
   Deployer depl = Deployer(DATA_DIR / "source", DATA_DIR / "app", "");
@@ -95,7 +95,7 @@ TEST_CASE("Loadorder is being changed", "[.deployer]")
   verifyDirsAreEqual(DATA_DIR / "app", DATA_DIR / "target" / "mod012", true);
 }
 
-TEST_CASE("Profiles", "[.deployer]")
+TEST_CASE("Profiles", "[deployer]")
 {
   resetAppDir();
   Deployer depl = Deployer(DATA_DIR / "source", DATA_DIR / "app", "");
@@ -119,7 +119,7 @@ TEST_CASE("Profiles", "[.deployer]")
   }
 }
 
-TEST_CASE("Get mod conflicts", "[.deployer]")
+TEST_CASE("Get mod conflicts", "[deployer]")
 {
   Deployer depl = Deployer(DATA_DIR / "source", DATA_DIR / "app", "");
   depl.addProfile();
@@ -135,7 +135,7 @@ TEST_CASE("Get mod conflicts", "[.deployer]")
   REQUIRE(conflicts.contains(0));
 }
 
-TEST_CASE("Get file conflicts", "[.deployer]")
+TEST_CASE("Get file conflicts", "[deployer]")
 {
   Deployer depl = Deployer(DATA_DIR / "source", DATA_DIR / "app", "");
   depl.addProfile();
@@ -148,7 +148,7 @@ TEST_CASE("Get file conflicts", "[.deployer]")
   REQUIRE(conflicts.size() == 3);
 }
 
-TEST_CASE("Conflict groups are created", "[.deployer]")
+TEST_CASE("Conflict groups are created", "[deployer]")
 {
   Deployer depl(DATA_DIR / "source" / "conflicts", DATA_DIR / "app", "");
   depl.addProfile();
@@ -161,7 +161,7 @@ TEST_CASE("Conflict groups are created", "[.deployer]")
                  std::vector<std::vector<int>>{ { 0, 1, 2, 3, 5 }, { 4, 6 }, { 7 } }));
 }
 
-TEST_CASE("Mods are sorted", "[.deployer]")
+TEST_CASE("Mods are sorted", "[deployer]")
 {
   Deployer depl(DATA_DIR / "source" / "conflicts", DATA_DIR / "app", "");
   depl.addProfile();
@@ -179,7 +179,7 @@ TEST_CASE("Mods are sorted", "[.deployer]")
                                                                                     { 7, true } }));
 }
 
-TEST_CASE("Case matching deployer", "[.deployer]")
+TEST_CASE("Case matching deployer", "[deployer]")
 {
   resetAppDir();
   sfs::remove_all(DATA_DIR / "source" / "case_matching" / "0");
@@ -204,7 +204,7 @@ TEST_CASE("Case matching deployer", "[.deployer]")
                      false);
 }
 
-TEST_CASE("External changes are handeld", "[.deployer]")
+TEST_CASE("External changes are handeld", "[deployer]")
 {
   resetAppDir();
   resetStagingDir();
@@ -253,7 +253,7 @@ TEST_CASE("External changes are handeld", "[.deployer]")
   REQUIRE(sfs::equivalent(DATA_DIR / "staging" / "2" / "0.txt", DATA_DIR / "app" / "0.txt"));
 }
 
-TEST_CASE("Files are deployed as sym links", "[.deployer]")
+TEST_CASE("Files are deployed as sym links", "[deployer]")
 {
   resetAppDir();
   Deployer depl = Deployer(DATA_DIR / "source", DATA_DIR / "app", "", Deployer::sym_link);

--- a/tests/test_fomodinstaller.cpp
+++ b/tests/test_fomodinstaller.cpp
@@ -2,7 +2,7 @@
 #include "test_utils.h"
 #include <catch2/catch_test_macros.hpp>
 
-TEST_CASE("Required files are detected", "[.fomod]")
+TEST_CASE("Required files are detected", "[fomod]")
 {
   fomod::FomodInstaller installer;
   installer.init(DATA_DIR / "source" / "fomod" / "fomod" / "simple.xml");
@@ -16,7 +16,7 @@ TEST_CASE("Required files are detected", "[.fomod]")
   REQUIRE_THAT(files, Catch::Matchers::Equals(target));
 }
 
-TEST_CASE("Steps are executed", "[.fomod]")
+TEST_CASE("Steps are executed", "[fomod]")
 {
   fomod::FomodInstaller installer;
   installer.init(DATA_DIR / "source" / "fomod" / "fomod" / "steps.xml");
@@ -44,7 +44,7 @@ TEST_CASE("Steps are executed", "[.fomod]")
   REQUIRE_THAT(result, Catch::Matchers::Equals(target));
 }
 
-TEST_CASE("Installation matrix is parsed", "[.fomod]")
+TEST_CASE("Installation matrix is parsed", "[fomod]")
 {
   fomod::FomodInstaller installer;
   installer.init(DATA_DIR / "source" / "fomod" / "fomod" / "matrix.xml");

--- a/tests/test_fomodinstaller.cpp
+++ b/tests/test_fomodinstaller.cpp
@@ -16,7 +16,7 @@ TEST_CASE("Required files are detected", "[fomod]")
   REQUIRE_THAT(files, Catch::Matchers::Equals(target));
 }
 
-TEST_CASE("Steps are executed", "[fomod]")
+TEST_CASE("Steps are executed", "[fomod][!shouldfail]")
 {
   fomod::FomodInstaller installer;
   installer.init(DATA_DIR / "source" / "fomod" / "fomod" / "steps.xml");
@@ -44,7 +44,7 @@ TEST_CASE("Steps are executed", "[fomod]")
   REQUIRE_THAT(result, Catch::Matchers::Equals(target));
 }
 
-TEST_CASE("Installation matrix is parsed", "[fomod]")
+TEST_CASE("Installation matrix is parsed", "[fomod][!shouldfail]")
 {
   fomod::FomodInstaller installer;
   installer.init(DATA_DIR / "source" / "fomod" / "fomod" / "matrix.xml");

--- a/tests/test_installer.cpp
+++ b/tests/test_installer.cpp
@@ -62,7 +62,7 @@ TEST_CASE("Installer options", "[installer]")
   }
 }
 
-TEST_CASE("Root levels", "[installer]")
+TEST_CASE("Root levels", "[installer][!shouldfail]")
 {
   resetStagingDir();
   SECTION("Level 0")

--- a/tests/test_installer.cpp
+++ b/tests/test_installer.cpp
@@ -6,14 +6,14 @@
 #include <vector>
 
 
-TEST_CASE("Files are extracted", "[.installer]")
+TEST_CASE("Files are extracted", "[installer]")
 {
   resetStagingDir();
   Installer::extract(DATA_DIR / "source" / "mod0.tar.gz", DATA_DIR / "staging" / "extract");
   verifyDirsAreEqual(DATA_DIR / "source" / "0", DATA_DIR / "staging" / "extract");
 }
 
-TEST_CASE("Mods are (un)installed", "[.installer]")
+TEST_CASE("Mods are (un)installed", "[installer]")
 {
   resetStagingDir();
   Installer::install(DATA_DIR / "source" / "mod0.tar.gz",
@@ -29,7 +29,7 @@ TEST_CASE("Mods are (un)installed", "[.installer]")
   }
 }
 
-TEST_CASE("Installer options", "[.installer]")
+TEST_CASE("Installer options", "[installer]")
 {
   resetStagingDir();
   SECTION("Upper case conversion")
@@ -62,7 +62,7 @@ TEST_CASE("Installer options", "[.installer]")
   }
 }
 
-TEST_CASE("Root levels", "[.installer]")
+TEST_CASE("Root levels", "[installer]")
 {
   resetStagingDir();
   SECTION("Level 0")

--- a/tests/test_lootdeployer.cpp
+++ b/tests/test_lootdeployer.cpp
@@ -17,7 +17,7 @@ void resetFiles()
 }
 
 
-TEST_CASE("State is read", "[.loot]")
+TEST_CASE("State is read", "[loot]")
 {
   resetFiles();
   LootDeployer depl(
@@ -30,7 +30,7 @@ TEST_CASE("State is read", "[.loot]")
                  std::vector<std::tuple<int, bool>>{ { -1, true }, { -1, false }, { -1, true }, { -1, true } }));
 }
 
-TEST_CASE("Load order can be edited", "[.loot]")
+TEST_CASE("Load order can be edited", "[loot]")
 {
   resetFiles();
   LootDeployer depl(
@@ -50,7 +50,7 @@ TEST_CASE("Load order can be edited", "[.loot]")
   REQUIRE_THAT(depl.getLoadorder(), Catch::Matchers::Equals(depl2.getLoadorder()));
 }
 
-TEST_CASE("Profiles are managed", "[.loot]")
+TEST_CASE("Profiles are managed", "[loot]")
 {
   resetFiles();
   LootDeployer depl(

--- a/tests/test_moddedapplication.cpp
+++ b/tests/test_moddedapplication.cpp
@@ -10,7 +10,7 @@
 
 const int INSTALLER_FLAGS = Installer::preserve_case | Installer::preserve_directories;
 
-TEST_CASE("Mods are installed", "[.app]")
+TEST_CASE("Mods are installed", "[app]")
 {
   resetStagingDir();
   ModdedApplication app(DATA_DIR / "staging", "test");
@@ -40,7 +40,7 @@ TEST_CASE("Mods are installed", "[.app]")
   REQUIRE(mod_info[0].mod.name == "mod 0->2");
 }
 
-TEST_CASE("Deployers are added", "[.app]")
+TEST_CASE("Deployers are added", "[app]")
 {
   resetStagingDir();
   resetAppDir();
@@ -65,7 +65,7 @@ TEST_CASE("Deployers are added", "[.app]")
   verifyDirsAreEqual(DATA_DIR / "app", DATA_DIR / "target" / "mod012", true);
 }
 
-TEST_CASE("State is saved", "[.app]")
+TEST_CASE("State is saved", "[app]")
 {
   resetStagingDir();
   resetAppDir();
@@ -111,7 +111,7 @@ TEST_CASE("State is saved", "[.app]")
   sfs::remove_all(DATA_DIR / "app_2");
 }
 
-TEST_CASE("Groups update loadorders", "[.app]")
+TEST_CASE("Groups update loadorders", "[app]")
 {
   resetStagingDir();
   ModdedApplication app(DATA_DIR / "staging", "test");
@@ -148,7 +148,7 @@ TEST_CASE("Groups update loadorders", "[.app]")
                Catch::Matchers::Equals(std::vector<std::tuple<int, bool>>{ { 2, true } }));
 }
 
-TEST_CASE("Mods are split", "[.app]")
+TEST_CASE("Mods are split", "[app]")
 {
   resetStagingDir();
   ModdedApplication app(DATA_DIR / "staging", "test");
@@ -188,7 +188,7 @@ TEST_CASE("Mods are split", "[.app]")
   verifyDirsAreEqual(DATA_DIR / "staging", DATA_DIR / "target" / "split");
 }
 
-TEST_CASE("Mods are uninstalled", "[.app]")
+TEST_CASE("Mods are uninstalled", "[app]")
 {
   resetStagingDir();
   ModdedApplication app(DATA_DIR / "staging", "test");

--- a/tests/test_openmwdeployer.cpp
+++ b/tests/test_openmwdeployer.cpp
@@ -23,7 +23,7 @@ void resetOpenMwFiles()
   sfs::copy(target_source, target_target);
 }
 
-TEST_CASE("State is read", "[openmw]")
+TEST_CASE("State is read", "[openmw][!shouldfail]")
 {
   resetOpenMwFiles();
   
@@ -58,7 +58,7 @@ TEST_CASE("State is read", "[openmw]")
   verifyFilesAreEqual(DATA_DIR / "target" / "openmw" / "target" / "openmw.cfg", DATA_DIR / "target" / "openmw" / "0" / "openmw.cfg");
 }
 
-TEST_CASE("Load order can be edited", "[openmw]")
+TEST_CASE("Load order can be edited", "[openmw][!shouldfail]")
 {
   resetOpenMwFiles();
   
@@ -99,7 +99,7 @@ TEST_CASE("Load order can be edited", "[openmw]")
   REQUIRE_THAT(p_depl.getLoadorder(), Catch::Matchers::Equals(p_depl_2.getLoadorder()));
 }
 
-TEST_CASE("Profiles are managed", "[openmw]")
+TEST_CASE("Profiles are managed", "[openmw][!shouldfail]")
 {
   resetOpenMwFiles();
   

--- a/tests/test_openmwdeployer.cpp
+++ b/tests/test_openmwdeployer.cpp
@@ -23,7 +23,7 @@ void resetOpenMwFiles()
   sfs::copy(target_source, target_target);
 }
 
-TEST_CASE("State is read", "[.openmw]")
+TEST_CASE("State is read", "[openmw]")
 {
   resetOpenMwFiles();
   
@@ -58,7 +58,7 @@ TEST_CASE("State is read", "[.openmw]")
   verifyFilesAreEqual(DATA_DIR / "target" / "openmw" / "target" / "openmw.cfg", DATA_DIR / "target" / "openmw" / "0" / "openmw.cfg");
 }
 
-TEST_CASE("Load order can be edited", "[.openmw]")
+TEST_CASE("Load order can be edited", "[openmw]")
 {
   resetOpenMwFiles();
   
@@ -99,7 +99,7 @@ TEST_CASE("Load order can be edited", "[.openmw]")
   REQUIRE_THAT(p_depl.getLoadorder(), Catch::Matchers::Equals(p_depl_2.getLoadorder()));
 }
 
-TEST_CASE("Profiles are managed", "[.openmw]")
+TEST_CASE("Profiles are managed", "[openmw]")
 {
   resetOpenMwFiles();
   

--- a/tests/test_reversedeployer.cpp
+++ b/tests/test_reversedeployer.cpp
@@ -149,7 +149,7 @@ TEST_CASE("Deployed files are ignored", "[revdepl]")
                Catch::Matchers::UnorderedEquals(new_ignored_target));
 }
 
-TEST_CASE("Managed files are deployed", "[revdepl]")
+TEST_CASE("Managed files are deployed", "[revdepl][!shouldfail]")
 {
   resetDirs();
   Deployer depl(DATA_DIR / "source" / "revdepl" / "data",

--- a/tests/test_reversedeployer.cpp
+++ b/tests/test_reversedeployer.cpp
@@ -34,7 +34,7 @@ std::vector<std::string> files_to_be_ignored = {
   (sfs::path("c") / "3").string()
 };
 
-TEST_CASE("Ignored files are updated", "[.revdepl]")
+TEST_CASE("Ignored files are updated", "[revdepl]")
 {
   resetDirs();
   ReverseDeployer depl(DATA_DIR / "source" / "revdepl" / "source",
@@ -56,7 +56,7 @@ TEST_CASE("Ignored files are updated", "[.revdepl]")
                Catch::Matchers::UnorderedEquals(files_to_be_ignored));
 }
 
-TEST_CASE("Managed files are updated", "[.revdepl]")
+TEST_CASE("Managed files are updated", "[revdepl]")
 {
   // No extra files
   resetDirs();
@@ -86,7 +86,7 @@ TEST_CASE("Managed files are updated", "[.revdepl]")
                Catch::Matchers::UnorderedEquals(managed_target));
 }
 
-TEST_CASE("Deployed files are ignored", "[.revdepl]")
+TEST_CASE("Deployed files are ignored", "[revdepl]")
 {
   resetDirs();
   Deployer depl(DATA_DIR / "source" / "revdepl" / "data",
@@ -149,7 +149,7 @@ TEST_CASE("Deployed files are ignored", "[.revdepl]")
                Catch::Matchers::UnorderedEquals(new_ignored_target));
 }
 
-TEST_CASE("Managed files are deployed", "[.revdepl]")
+TEST_CASE("Managed files are deployed", "[revdepl]")
 {
   resetDirs();
   Deployer depl(DATA_DIR / "source" / "revdepl" / "data",

--- a/tests/test_tagconditionnode.cpp
+++ b/tests/test_tagconditionnode.cpp
@@ -98,7 +98,7 @@ TEST_CASE("Expressions of depth 1 are parsed", "[tags]")
   REQUIRE(node2.evaluate(files.at(1)));
 }
 
-TEST_CASE("Complex expressions are parsed", "[tags]")
+TEST_CASE("Complex expressions are parsed", "[tags][!shouldfail]")
 {
   std::vector<TagCondition> conditions{
     { false, TagCondition::Type::file_name, false, "*.txt" },

--- a/tests/test_tagconditionnode.cpp
+++ b/tests/test_tagconditionnode.cpp
@@ -4,7 +4,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 
-TEST_CASE("Expressions are validated", "[.tags]")
+TEST_CASE("Expressions are validated", "[tags]")
 {
   REQUIRE_FALSE(TagConditionNode::expressionIsValid("", 1));
   REQUIRE_FALSE(TagConditionNode::expressionIsValid("and", 1));
@@ -37,7 +37,7 @@ TEST_CASE("Expressions are validated", "[.tags]")
   REQUIRE(TagConditionNode::expressionIsValid("not(not0) and (1) or    2", 3));
 }
 
-TEST_CASE("Single node detects files", "[.tags]")
+TEST_CASE("Single node detects files", "[tags]")
 {
   std::vector<TagCondition> conditions{
     { false, TagCondition::Type::file_name, false, "*.txt" },
@@ -80,7 +80,7 @@ TEST_CASE("Single node detects files", "[.tags]")
   REQUIRE_FALSE(node_7.evaluate(files.at(1)));
 }
 
-TEST_CASE("Expressions of depth 1 are parsed", "[.tags]")
+TEST_CASE("Expressions of depth 1 are parsed", "[tags]")
 {
   std::vector<TagCondition> conditions{ { false, TagCondition::Type::file_name, false, "*.txt" },
                                         { false, TagCondition::Type::file_name, false, "*12*abc" },
@@ -98,7 +98,7 @@ TEST_CASE("Expressions of depth 1 are parsed", "[.tags]")
   REQUIRE(node2.evaluate(files.at(1)));
 }
 
-TEST_CASE("Complex expressions are parsed", "[.tags]")
+TEST_CASE("Complex expressions are parsed", "[tags]")
 {
   std::vector<TagCondition> conditions{
     { false, TagCondition::Type::file_name, false, "*.txt" },

--- a/tests/test_tool.cpp
+++ b/tests/test_tool.cpp
@@ -2,7 +2,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 
-TEST_CASE("Overwrite commands are generated", "[.tool]")
+TEST_CASE("Overwrite commands are generated", "[tool]")
 {
   const std::string command_string = "my command string";
   Tool tool("t", "", command_string);
@@ -11,7 +11,7 @@ TEST_CASE("Overwrite commands are generated", "[.tool]")
   REQUIRE(tool.getCommand(true) == "flatpak-spawn --host " + command_string);
 }
 
-TEST_CASE("Native commands are generated", "[.tool]")
+TEST_CASE("Native commands are generated", "[tool]")
 {
   Tool tool_1("t1", "", "prog", "", {}, "");
   REQUIRE(tool_1.getCommand(false) == R"("prog")");
@@ -25,7 +25,7 @@ TEST_CASE("Native commands are generated", "[.tool]")
   REQUIRE(tool_4.getCommand(true) == R"(flatpak-spawn --host --directory="/tmp" --env=VAR_1="VAL_1" --env=VAR_2="VAL_2" "/bin/prog" -v -a 2)");
 }
 
-TEST_CASE("Wine commands are generated", "[.tool]")
+TEST_CASE("Wine commands are generated", "[tool]")
 {
   Tool tool_1("t1", "", "/bin/prog.exe", "", "", {}, "");
   REQUIRE(tool_1.getCommand(false) == R"(wine "/bin/prog.exe")");
@@ -35,7 +35,7 @@ TEST_CASE("Wine commands are generated", "[.tool]")
   REQUIRE(tool_2.getCommand(true) == R"(flatpak-spawn --host --directory="/tmp" --env=VAR_1="VAL_1" --env=WINEPREFIX="/tmp/wine_prefix" wine "/bin/prog.exe" -b)");
 }
 
-TEST_CASE("Protontricks commands are generated", "[.tool]")
+TEST_CASE("Protontricks commands are generated", "[tool]")
 {
   Tool tool_1("t1", "", "/bin/prog.exe", false, 220, "/tmp", {{"VAR_1", "VAL_1"}}, "-arg", "-parg");
   REQUIRE(tool_1.getCommand(false) == R"(cd "/tmp"; VAR_1="VAL_1" protontricks-launch --appid 220 -parg "/bin/prog.exe" -arg)");
@@ -45,7 +45,7 @@ TEST_CASE("Protontricks commands are generated", "[.tool]")
     R"(flatpak run --command=protontricks-launch com.github.Matoking.protontricks --appid 220 -parg "/bin/prog.exe" -arg)");
 }
 
-TEST_CASE("Steam commands are generated", "[.tool]")
+TEST_CASE("Steam commands are generated", "[tool]")
 {
   Tool tool_1("t1", "", 220, false);
   REQUIRE(tool_1.getCommand(false) == "steam -applaunch 220");
@@ -54,7 +54,7 @@ TEST_CASE("Steam commands are generated", "[.tool]")
   REQUIRE(tool_2.getCommand(true) == "flatpak-spawn --host flatpak run com.valvesoftware.Steam -applaunch 220");
 }
 
-TEST_CASE("State is serialized", "[.tool]")
+TEST_CASE("State is serialized", "[tool]")
 {
   std::vector<Tool> tools =
   {

--- a/tests/test_utils.h.in
+++ b/tests/test_utils.h.in
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BASE_PATH sfs::path("@PROJECT_SOURCE_DIR@")
+#define BASE_PATH sfs::path("@PROJECT_SOURCE_DIR@/tests")
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>


### PR DESCRIPTION
The fact that all the tests were hidden with the tags skill checked me hard. For testing it would be more useful if all or most tests were in the default list so that people would run tests. Otherwise its very easy to miss.

Added failing tests to xfail, atleast one of them appears to fail due to missing data files.

Reuse core object for tests and application.

Include tests in root CMakeLists.txt with standard cmake BUILD_TESTING option controlling whether its built or not..

https://cmake.org/cmake/help/git-stage/variable/BUILD_TESTING.html