### PR TITLE
Include implicit header for std::ranges::iota

### DIFF
--- a/src/core/reversedeployer.cpp
+++ b/src/core/reversedeployer.cpp
@@ -6,6 +6,7 @@
 #include <format>
 #include <fstream>
 #include <iostream>
+#include <numeric>
 #include <ranges>
 
 namespace sfs = std::filesystem;


### PR DESCRIPTION
GCC-15 stdlibc++ has changed its header includes meanings this doesn't get implicitly included anymore.

https://en.cppreference.com/w/cpp/algorithm/ranges/iota

```
/usr/bin/g++-15  -I/home/ask/sources/limo/build -I/home/ask/sources/limo -I/home/ask/sources/limo/build/core_autogen/include -I/home/ask/sources/limo/src -I/usr/include/loot -I/usr/include/jsoncpp -I/usr/include/unrar -std=gnu++23 -MD -MT CMakeFiles/core.dir/src/core/reversedeployer.cpp.o -MF CMakeFiles/core.dir/src/core/reversedeployer.cpp.o.d -o CMakeFiles/core.dir/src/core/reversedeployer.cpp.o -c /home/ask/sources/limo/src/core/reversedeployer.cpp
/home/ask/sources/limo/src/core/reversedeployer.cpp: In member function ‘virtual std::vector<std::vector<int> > ReverseDeployer::getConflictGroups() const’:
/home/ask/sources/limo/src/core/reversedeployer.cpp:125:8: error: ‘iota’ is not a member of ‘str’; did you mean ‘std::ranges::views::iota’?
  125 |   str::iota(group.begin(), group.end(), 0);
      |        ^~~~
In file included from /home/ask/sources/limo/src/core/reversedeployer.cpp:9:
/usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/ranges:784:26: note: ‘std::ranges::views::iota’ declared here
  784 |   inline constexpr _Iota iota{};
      |                          ^~~~
```

(clang uses gcc stdlibc++ unless instructed otherwise)
```
/usr/lib/llvm/21/bin/clang++  -I/home/ask/sources/limo/build -I/home/ask/sources/limo -I/home/ask/sources/limo/build/core_autogen/include -I/home/ask/sources/limo/src -I/usr/include/loot -I/usr/include/jsoncpp -I/usr/include/unrar -std=gnu++23 -MD -MT CMakeFiles/core.dir/src/core/reversedeployer.cpp.o -MF CMakeFiles/core.dir/src/core/reversedeployer.cpp.o.d -o CMakeFiles/core.dir/src/core/reversedeployer.cpp.o -c /home/ask/sources/limo/src/core/reversedeployer.cpp
/home/ask/sources/limo/src/core/reversedeployer.cpp:125:8: error: no member named 'iota' in namespace 'std::ranges'
  125 |   str::iota(group.begin(), group.end(), 0);
      |   ~~~~~^
1 error generated.
```