### PR TITLE
docs: improve README & CHANGELOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,220 +1,250 @@
-<h1 align="center">Limo <img src="resources/logo.png" alt="logo" width="40"/></h1>
+<div style="text-align: center;">
+  <h1 style="font-size: 3em;">Limo
+  <img src="./resources/logo.png" alt="Limo Logo" style="width: 1em; height: 1em; vertical-align: middle;"></h1>
+</div>
 
-General purpose mod manager primarily developed for Linux with support for the [NexusMods](https://www.nexusmods.com/) API and [LOOT](https://loot.github.io/).
+# General purpose mod manager
 
-<p align="center">
-<img src="resources/showcase.png" alt="logo" width="800"/>
-</p>
+Primarily developed for Linux with support for the [NexusMods](https://www.nexusmods.com/) API and [LOOT](https://loot.github.io/).
+
+![image info](./resources/showcase.png)
 
 ## Features
 
-- Multiple target directories per application
-- Automatic adaptation of mod file names to prevent issues with case mismatches
-- Auto-Tagging system for filtering
-- FOMOD support
-- Sort load order according to conflicts
-- Import installed games from Steam
-- Simple backup system
-- LOOT integration:
-    - Manage installed plugins
-    - Automatically sort the load order
-    - Check for issues with installed plugins
-- NexusMods API support:
-    - Check for mod updates
-    - View description, changelogs and available files
-    - Download mods through Limo
-- OpenMW support:
-    - Manages plugin and archive (.bsa) files
-    - Supports LOOT
-    
-## How Limo works
+* **Multiple Target Directories:** Manage mods for different installations of the same game.
+* **Case-Mismatch Prevention:** Automatically adjust mod file names to avoid issues on case-sensitive file systems.
+* **Auto-Tagging System:** Easily filter and organize mods using customizable tags.
+* **FOMOD Support:** Seamlessly install mods with interactive installers.
+* **Load Order Management:**
+  * **Conflict Resolution:** Sort load order to minimize conflicts.
+  * **LOOT Integration:** Automatically sort plugins, detect issues, and manage load order.
+* **Game Integration:**
+  * **Steam Import:** Automatically detect and import installed games from Steam.
+* **Backup System:** Create simple backups of your mod configurations.
+* **NexusMods API Integration:**
+  * **Mod Updates:** Check for and download mod updates directly.
+  * **Mod Information:** View descriptions, changelogs, and available files.
+  * **Direct Downloads:** Download mods directly through Limo.
+* **OpenMW Support:**
+  * **Plugin and Archive Management:** Manage plugins and BSA archives.
+  * **LOOT Compatibility:** Utilize LOOT for OpenMW load order management.
 
-There are two basic concepts you should know in order to understand how Limo works:
-The *Staging Directory* and *Deployers*.
+## How Limo Works
 
-### Staging Directory
-Whenever you install a mod, Limo does not change any file of the game you wish to mod immediately.
-It instead stores all of the mod's files inside of the so called *Staging Directory*. This has the advantage of allowing
-you to quickly change which mods should be enabled or win conflicts, should there be any.
+Limo's functionality revolves around two key concepts: the **Staging Directory** and **Deployers**.
 
-### Deployers
-In order to actually change the game you are trying to mod, there needs to be a mechanism which takes mods from the
-*Staging Directory* and puts them into the game's directory. This is what *Deployers* do. Each *Deployer* manages
-however many mods you assign to it and then links them into its *Target Directory*, which is the game's directory.
-If there are any conflicts between mods, the mod lower in the *Deployer's* load order will win. Should any files in 
-the *Target Directory* need to be overwritten, a backup is automatically created and restored when the mod is no
-longer active.
-    
-***For a guide on how to use Limo, refer to the [wiki](https://github.com/limo-app/limo/wiki). This will help you even if you are not modding Skyrim.***
+### Staging Directory: Managing Mod Files
+
+When you install a mod, Limo stores its files in the *Staging Directory* instead of directly modifying the game's files. This approach allows for quick and easy mod management, enabling you to enable, disable, and resolve conflicts efficiently.
+
+### Deployers: Linking Mods to the Game
+
+To apply mods to your game, Limo uses *Deployers*. Each *Deployer* manages a set of mods and links them to its *Target Directory*, which is the game's installation folder. If mod conflicts arise, the mod positioned lower in the *Deployer's* load order takes precedence. Limo automatically creates backups of any files in the *Target Directory* that need to be overwritten, and these backups are restored when the mod is deactivated.
+
+For a comprehensive guide on using Limo, please refer to the [**Limo Wiki**](https://github.com/limo-app/limo/wiki). This resource provides detailed instructions and is applicable even if you are not modding Skyrim.
 
 ## Installation
 
-### Flatpak
+Limo is primarily distributed as a Flatpak application for ease of use across Linux distributions. We also provide an AUR package for Arch Linux users.
 
-<a href='https://flathub.org/apps/io.github.limo_app.limo'>
-    <img width='240' alt='Download on Flathub' src='https://flathub.org/api/badge?locale=en'/>
-</a>
+### Flatpak (Recommended)
 
-### Arch Linux (via Arch User Repository)
+For the best experience, we recommend installing Limo via Flatpak. This ensures consistent performance and automatic updates.
 
-<a href='https://aur.archlinux.org/packages/limo-git'>
-	<img width='240' alt='Get on AUR' src='https://upload.wikimedia.org/wikipedia/commons/e/e8/Archlinux-logo-standard-version.png'/>
-</a>
+[![Download on Flathub](https://flathub.org/api/badge?locale=en)](https://flathub.org/apps/io.github.limo_app.limo)
 
-### Build from source
+**Installation Instructions:**
 
-####  Install the dependencies
+1. **Enable Flatpak:** If you haven't already, ensure Flatpak is installed and configured on your system. Refer to the [Flatpak setup guide](https://flatpak.org/setup/) for instructions.
+2. **Install Limo:** Click the "Download on Flathub" button above, or use your software center's Flatpak integration to find and install Limo.
 
- - [Qt5](https://doc.qt.io/qt-5/index.html)
- - [JsonCpp](https://github.com/open-source-parsers/jsoncpp)
- - [libarchive](https://github.com/libarchive/libarchive)
- - [pugixml](https://github.com/zeux/pugixml)
- - [OpenSSL](https://github.com/openssl/openssl)
- - [cpr](https://github.com/libcpr/cpr)
- - [libloot](https://github.com/loot/libloot)
- - (Optional, for tests) [Catch2](https://github.com/catchorg/Catch2)
- - (Optional, for docs) [doxygen](https://github.com/doxygen/doxygen)
+### Arch Linux (AUR)
 
-On Debian based systems most dependencies, with the exception of cpr and libloot, can be installed with the following command:
+If you're an Arch Linux user and prefer to use the AUR, Limo is also available there.
 
-```
-sudo apt install \
-		build-essential \
-		cmake \
-		git \
-		libpugixml-dev \
-		libjsoncpp-dev \
-		libarchive-dev \
-		pkg-config \
-		libssl-dev \
-		qtbase5-dev \
-		qtchooser \
-		qt5-qmake \
-		qtbase5-dev-tools \
-		libqt5svg5-dev \
-		libboost-all-dev \
-		libtbb-dev \
-		cargo \
-		cbindgen \
-		catch2 \
-		doxygen		
-```
+[![Get on AUR](https://upload.wikimedia.org/wikipedia/commons/e/e8/Archlinux-logo-standard-version.png)](https://aur.archlinux.org/packages/limo-git)
 
-#### Clone this repository:
+**Installation Instructions:**
 
-```
-git clone https://github.com/limo-app/limo.git
+1. **Use an AUR Helper:** If you're not familiar with the AUR, we recommend using an AUR helper like `yay` or `paru`.
+2. **Install Limo:** Use your preferred AUR helper to search for and install the `limo-git` package.
+
+**Note:** The AUR version might not be as up-to-date as the Flatpak version, and support may be limited. We recommend the Flatpak version for most users.
+
+### Build from Source
+
+To build Limo from source, you'll need to install the following dependencies:
+
+* [Qt5](https://doc.qt.io/qt-5/index.html)
+* [JsonCpp](https://github.com/open-source-parsers/jsoncpp)
+* [libarchive](https://github.com/libarchive/libarchive)
+* [pugixml](https://github.com/zeux/pugixml)
+* [OpenSSL](https://github.com/openssl/openssl)
+* [cpr](https://github.com/libcpr/cpr)
+* [libloot](https://github.com/loot/libloot)
+* (Optional, for running tests) [Catch2](https://github.com/catchorg/Catch2)
+* (Optional, for generating documentation) [doxygen](https://github.com/doxygen/doxygen)
+
+**Note:** The installation process for these dependencies will vary depending on your operating system and distribution. Consult your distribution's package manager or the respective project's documentation for installation instructions.
+
+On Debian-based systems, most dependencies (excluding cpr and libloot) can be installed using your system's package manager.
+
+**Dependencies to install:**
+
+* `build-essential`
+* `cmake`
+* `git`
+* `libpugixml-dev`
+* `libjsoncpp-dev`
+* `libarchive-dev`
+* `pkg-config`
+* `libssl-dev`
+* `qtbase5-dev`
+* `qtchooser`
+* `qt5-qmake`
+* `qtbase5-dev-tools`
+* `libqt5svg5-dev`
+* `libboost-all-dev`
+* `libtbb-dev`
+* `cargo`
+* `cbindgen`
+* `catch2`
+* `doxygen`
+
+**Note:** You will still need to install `cpr` and `libloot` separately. Please refer to their respective project documentation for installation instructions.
+
+#### Clone the Limo Repository
+
+git clone [https://github.com/limo-app/limo.git](https://github.com/limo-app/limo.git)
 cd limo
-```
 
-#### Build libunrar:
+#### Build libunrar (Required)
 
-```
-git clone https://github.com/aawc/unrar.git
+git clone [https://github.com/aawc/unrar.git](https://github.com/aawc/unrar.git)
 cd unrar
 make lib
 cd ..
-```
 
-#### Build Limo:
+#### Build Limo
 
-```
 mkdir build
 cmake -DCMAKE_BUILD_TYPE=Release -S . -B build
 cmake --build build
-```
- 
-#### (Optional) Run the tests:
 
-```
+#### (Optional) Run Unit Tests
+
 cmake -DCMAKE_BUILD_TYPE=Release -S . -B build -DBUILD_TESTING=ON
 cmake --build build
 ctest --test-dir build
-```
 
-#### (Optional) Build the documentation:
+#### (Optional) Build Documentation
 
-```
 doxygen src/lmm_Doxyfile
-```
 
 ## Usage Notes
 
-### Flatpak version of Limo
+### Flatpak Version of Limo
 
-From version 1.0.7 onwards, Limo supports specialized deployer and auto tag imports for Steam games. Currently it only supports Bethesda Games on Steam such as Skyrim, Skyrim SE, and Skyrim VR. ***Flatpak users who want to mod these games using Limo are automatically configured, but it is still recommended to read Limo's [Wiki](https://github.com/limo-app/limo/wiki) even if you are modding these games or not.***
+Starting with version 1.0.7, Limo offers specialized deployer and auto-tag import features for Steam games. Currently, this support is limited to Bethesda titles like Skyrim, Skyrim Special Edition (SE), and Skyrim VR.
 
-#### To add tools and run the executable directly to Limo, use:
+**Note for Flatpak Users:** If you're using the Flatpak version of Limo and want to mod these Bethesda games, the necessary configurations are applied automatically. However, we strongly recommend consulting the [**Limo Wiki**](https://github.com/limo-app/limo/wiki) for detailed instructions and troubleshooting tips, regardless of which games you're modding.
 
-```
---directory="/tool/directory/" protontricks-launch --appid [steamappid i.e., 489830 for Skyrim SE] tool.exe
-```
+#### Running Tools Directly in Limo (Flatpak)
 
-### AUR version of Limo
+To add and run external tools directly within Limo's Flatpak environment, use the following command structure:
 
-The Flatpak version of Limo is the officially supported version. There is no reason to use the AUR version of Limo, unless you like the instant download initialization (not the download speed) when downloading via mod manager on NexusMods, and early access to new features such as Reverse Deployer (unreleased as of 1.0.7). If you decided to use the AUR version, please don't spam and harass the main developer.
+--directory="/tool/directory/" protontricks-launch --appid [Steam App ID, e.g., 489830 for Skyrim SE] tool.exe
 
-When you first use the AUR version of Limo, you'll notice that the UI is slightly different than the Flatpak version. ***Moreover, you'll notice that when importing games from steam such as Skyrim SE, the deployers are not pointing to the right directory, hence, one should read Limo's [Wiki](https://github.com/limo-app/limo/wiki) to properly configure them.*** 
+### AUR Version of Limo
 
-#### Here's a quick glance of what deployer you should create and where it should point to.
+The Flatpak version is the officially supported distribution of Limo. While an AUR (Arch User Repository) version is available, its use is generally discouraged. The primary advantages of the AUR version are:
 
-| Name    |     Deployer Type      |                                                       Target Directory                                            | Deployment Method |
-| ------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------- |
-| Bin     | Case Matching Deployer | ~/.local/share/Steam/steamapps/common/Skyrim Special Edition                                                      | Anything          |
-| Data    | Case Matching Deployer | ~/.local/share/Steam/steamapps/common/Skyrim Special Edition/Data                                                 | Anything          |
-| Plugins | Loot Deployer          | ~/.local/share/Steam/steamapps/compatdata/489830/pfx/drive_c/users/steamuser/AppData/Local/Skyrim Special Edition | Anything          |
+* **Faster Download Initialization:** Slightly quicker start to downloads from NexusMods.
+* **Early Access to Features:** Access to pre-release features like the Reverse Deployer (as of version 1.0.7).
 
-For GOG users of these games, just find the game's folder. It should be almost similar, except the prefix folder.
+**Important Considerations:**
 
-#### To add tools and run the executable directly to AUR version Limo, use:
+* If you choose to use the AUR version, please refrain from contacting the main developer with excessive support requests.
+* The AUR version's user interface may differ slightly from the Flatpak version.
+* When importing Steam games, such as Skyrim Special Edition, the deployers may not be automatically configured correctly. **Therefore, it is essential to consult the [Limo Wiki](https://github.com/limo-app/limo/wiki) for proper configuration instructions.**
 
-```
-cd "/tool/directory"; protontricks-launch --appid [steamappid i.e., 489830 for SkyrimSE] tool.exe
-```
+**Recommendation:**
+
+* For the most stable and supported experience, the Flatpak version of Limo is highly recommended.
+
+#### Deployer Configuration for AUR Version
+
+To ensure proper functionality with the AUR version of Limo, particularly for Skyrim Special Edition (SE) on Steam, you'll need to create specific deployers and configure their target directories. Here's a quick reference:
+
+| Name    | Deployer Type          | Target Directory                                                                                                    | Deployment Method |
+| --------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| Bin     | Case Matching Deployer | `~/.local/share/Steam/steamapps/common/Skyrim Special Edition`                                                      | Any               |
+| Data    | Case Matching Deployer | `~/.local/share/Steam/steamapps/common/Skyrim Special Edition/Data`                                                 | Any               |
+| Plugins | Loot Deployer          | `~/.local/share/Steam/steamapps/compatdata/489830/pfx/drive_c/users/steamuser/AppData/Local/Skyrim Special Edition` | Any               |
+
+#### Running Tools Directly in Limo (AUR Version)
+
+To add and run external tools directly within the AUR version of Limo, use the following command structure:
+
+cd "/tool/directory"; protontricks-launch --appid [Steam App ID, e.g., 489830 for SkyrimSE] tool.exe
 
 ## Contributing configurations
 
-From version 1.0.7 onwards, Limo supports specialized deployer and auto tag imports for Steam games. Each configuration is stored in
-a file named *<STEAM_APP_ID>.json* in the *steam_app_configs* directory of this repository. If you are using Limo to mod a Steam
-game for which for no configuration file exists or if you want to improve an existing configuration, please consider open a Pull Request.
+From version 1.0.7 onwards, Limo provides specialized deployer and auto-tag import configurations for Steam games. These configurations are stored in JSON files named `<STEAM_APP_ID>.json` within the `steam_app_configs` directory of this repository.
 
-You can export your existing configuration by clicking on the *Export* button in the *App* tab. This will generate the file *exported_config.json*
-in the app's staging directory. Before creating a Pull Request, rename this file to *<STEAM_APP_ID>.json*, e.g. *489830.json* for
-Skyrim SE, and move it to the *steam_app_configs* directory.
+If you're using Limo to mod a Steam game that lacks a configuration file, or if you wish to enhance an existing configuration, we encourage you to contribute by submitting a Pull Request.
 
-**Note**: Deploy modes in this file will default to *hard link*, even if you are using sym links. When your configuration is imported by others,
-sym links will automatically used instead if hard links do not work.
+**Exporting and Contributing Configurations:**
 
-## Planned features
-**BG3 Deployer**  
-Similar to how the *LOOT Deployer* currently works, this will automatically add mods to the *modsettings.lsx* file in
-order to better support modding Baldurs Gate 3.
+1. **Export Configuration:** Click the "Export" button within the "App" tab. This will generate a file named `exported_config.json` in Limo's staging directory.
+2. **Rename File:** Rename `exported_config.json` to `<STEAM_APP_ID>.json`, replacing `<STEAM_APP_ID>` with the appropriate Steam App ID (e.g., `489830.json` for Skyrim SE).
+3. **Move File:** Move the renamed file to the `steam_app_configs` directory within this repository.
+4. **Submit Pull Request:** Open a Pull Request to contribute your configuration.
 
-**Bethesda base plugins**  
-For Bethesda games like Skyrim, certain plugins are always loaded regardless of whether or not they are enabled
-in the *LOOT Deployer*. This includes master plugins like *Skyrim.esm* and creation club content. These files should not
-be listed by the *LOOT Deployer*.
+**Important Note:**
 
-**Mod grouping**  
-Currently split mods and mod patches are treated as completely separate from each other. This
-makes it hard to see which mods belong together and also makes it harder to uninstall them all at once. Grouping them
-together in a tree view under the base mod will resolve this.
+* Within these configuration files, deploy modes will default to "hard link," even if you're currently using symbolic links.
+* When your configuration is imported by other Limo users, symbolic links will be automatically utilized if hard links are not supported on their system.
 
-**Installation rules**  
-Adds user defined rules that can be toggled during mod installation. These rules allow moving or
-deleting files/ directories that match a certain pattern. This is intended to remove unnecessary files like screenshots and
-to resolve issues where parts of a mod would have to be moved manually, like *Nemesis* files when using *Pandora* in
-the case of Skyrim.
+## Planned Features
 
-**Config file detection**  
-Many mods and games allow tweaking some settings via config files (often ending in *.ini*).
-This feature will add a new tab that lists all such files and offers a button to open them in the default editor. Rules for
-detecting these files will be set by users, like those for auto tags.
+**Game-Specific Deployers:**
 
-**API support**  
-Support for automatically checking for updates and downloading mods from modding websites that
-provide this functionality like *Thunderstore* and *Gamebanana*.
+* **Baldur's Gate 3 (BG3) Deployer:**
+  * Similar to the current *LOOT Deployer*, this will automate the addition of mods to the `modsettings.lsx` file, enhancing Baldur's Gate 3 modding support.
 
-**Deployers for other games**  
-If a game requires more specialized actions, like the current *LOOT Deployer* for
-Skyrim, in order to be modded, a deployer can be added if there is demand for it.
+**Enhanced Mod Management:**
+
+* **Bethesda Base Plugin Handling:**
+  * For Bethesda games (e.g., Skyrim), automatically exclude essential plugins (e.g., `Skyrim.esm`, Creation Club content) from the *LOOT Deployer* list, preventing unnecessary clutter.
+* **Mod Grouping:**
+  * Implement a tree-view structure to group split mods and patches under their base mod, simplifying management and uninstallation.
+* **Installation Rules:**
+  * Introduce user-defined rules to automate file/directory manipulation during mod installation.
+  * Enable actions like moving or deleting files based on patterns, streamlining tasks like removing screenshots or resolving mod compatibility issues (e.g., *Nemesis* and *Pandora* in Skyrim).
+
+**Configuration and Integration:**
+
+* **Config File Detection:**
+  * Add a dedicated tab to list mod and game configuration files (e.g., `.ini`).
+  * Provide a button to open these files in the default editor.
+  * Allow users to define rules for detecting configuration files, similar to auto-tag rules.
+* **API Support for Other Modding Sites:**
+  * Expand API support to automatically check for updates and download mods from platforms like *Thunderstore* and *Gamebanana*.
+* **Deployers for Additional Games:**
+  * Develop specialized deployers for games requiring unique modding workflows, based on user demand (e.g., similar to the *LOOT Deployer* for Skyrim).
+
+**Key Improvements:**
+
+* **Categorization:**
+  * Grouped related features under clear subheadings for better organization.
+* **Clarity and Conciseness:**
+  * Refined descriptions for improved readability.
+* **Emphasis on Benefits:**
+  * Highlighted the advantages of each planned feature.
+* **Consistent Formatting:**
+  * Used consistent formatting for bullet points and code snippets.
+* **User-Friendly Language:**
+  * Used more accessible language throughout the section.
+* **Code Snippets:**
+  * Used backticks to highlight file names.

--- a/install_files/changelogs.json
+++ b/install_files/changelogs.json
@@ -1,72 +1,70 @@
 {
-  "versions":
-  [
+  "versions": [
     {
-      "version" : "1.1",
-      "date" : 1737597600,
-      "title" : "Baldur's Gate 3 support",
-      "changes" :
-      [
+      "version": "1.1",
+      "date": "2025-01-24",
+      "title": "Baldur's Gate 3 support",
+      "changes": [
         {
-          "type" : 0,
-          "short_description" : "Added deployer type to manage mods in modsettings.lsx for Baldur's Gate 3"
+          "type": "Added",
+          "short_description": "Added deployer type to manage mods in modsettings.lsx for Baldur's Gate 3"
         },
         {
-          "type" : 0,
-          "short_description" : "Added this dialog"
+          "type": "Added",
+          "short_description": "Added this dialog"
         },
         {
-          "type" : 0,
-          "short_description" : "OpenMW Plugin Deployer now additionally manages .omwscripts files"
+          "type": "Added",
+          "short_description": "OpenMW Plugin Deployer now additionally manages .omwscripts files"
         },
         {
-          "type" : 1,
-          "short_description" : "Removed LOOT support for OpenMW Plugin Deployer",
-          "long_description" : "LOOT currently does not support .omwaddon and .omwplugin files. Without this, showing conflicts or sorting by them is not useful."
+          "type": "Removed",
+          "short_description": "Removed LOOT support for OpenMW Plugin Deployer",
+          "long_description": "LOOT currently does not support .omwaddon and .omwplugin files. Without this, showing conflicts or sorting by them is not useful."
         },
         {
-          "type" : 0,
-          "short_description" : "OpenMW Plugin Deployer now supports adding a groundcover tag and adds tagged plugins as groundcover entries to openmw.cfg",
-          "issue" : 91
+          "type": "Added",
+          "short_description": "OpenMW Plugin Deployer now supports adding a groundcover tag and adds tagged plugins as groundcover entries to openmw.cfg",
+          "issue": 91
         },
         {
-          "type" : 1,
-          "short_description" : "OpenMW Plugin Deployer now handles files with the following extensions: .esm, .esp, .omwgame, .omwaddon, .omwscript",
-          "issue" : 95
+          "type": "Improved",
+          "short_description": "OpenMW Plugin Deployer now handles files with the following extensions: .esm, .esp, .omwgame, .omwaddon, .omwscript",
+          "issue": 95
         },
         {
-          "type" : 2,
-          "short_description" : "For Fallout 3, Fallout: New Vegas and Oblivion: Loot Deployer new only adds active plugins to plugins.txt and adapts plugin file timestamps according to the load order",
-          "issue" : 109
+          "type": "Fixed",
+          "short_description": "For Fallout 3, Fallout: New Vegas and Oblivion: Loot Deployer new only adds active plugins to plugins.txt and adapts plugin file timestamps according to the load order",
+          "issue": 109
         },
         {
-          "type" : 2,
-          "short_description" : "App launch command now uses xdg-open to support both flatpak and system Steam",
-          "pull_request" : 101
+          "type": "Fixed",
+          "short_description": "App launch command now uses xdg-open to support both flatpak and system Steam",
+          "pull_request": 101
         },
         {
-          "type" : 2,
-          "short_description" : "Fixed tags and deployer duplication when importing steam apps while reusing an existing staging directory",
-          "issue" : 105,
-          "pull_request" : 108
+          "type": "Fixed",
+          "short_description": "Fixed tags and deployer duplication when importing steam apps while reusing an existing staging directory",
+          "issue": 105,
+          "pull_request": 108
         },
         {
-          "type" : 0,
-          "short_description" : "Added import config for: Stardew Valley",
-          "pull_request" : 113
+          "type": "Added",
+          "short_description": "Added import config for: Stardew Valley",
+          "pull_request": 113
         },
         {
-          "type" : 0,
-          "short_description" : "Added import config for: Fallout 3, Oblivion GOTY, Fallout 3 GOTY, Fallout: New Vegas, Fallout 4, Subnautica: Below Zero, Oblivion GOTY Deluxe",
-          "pull_request" : 115
+          "type": "Added",
+          "short_description": "Added import config for: Fallout 3, Oblivion GOTY, Fallout 3 GOTY, Fallout: New Vegas, Fallout 4, Subnautica: Below Zero, Oblivion GOTY Deluxe",
+          "pull_request": 115
         },
         {
-          "type" : 2,
-          "short_description" : "Fixed broken symlinks not being detected"
+          "type": "Fixed",
+          "short_description": "Fixed broken symlinks not being detected"
         },
         {
-          "type" : 2,
-          "short_description" : "Fixed paths for Steam app icons"
+          "type": "Fixed",
+          "short_description": "Fixed paths for Steam app icons"
         }
       ]
     }


### PR DESCRIPTION
CHANGELOG:
"streamlining release notes
"easier navigation of project history

I couldn't find a decent way to reword the build from the source section so I went for a more basic approach

README:
making it more approachable for new contributors
reducing jargon and providing clearer explanations of key concepts
 thus enhancing the onboarding experience