### PR TITLE
Fix #190: Separate load list into two calls to preserve libloot compatiblity

### DIFF
--- a/src/core/lootdeployer.cpp
+++ b/src/core/lootdeployer.cpp
@@ -187,7 +187,8 @@ void LootDeployer::sortModsByConflicts(std::optional<ProgressNode*> progress_nod
   if(!sfs::exists(prelude_path))
     prelude_path = "";
   loot_handle->GetDatabase().LoadMasterlistWithPrelude(master_list_path, prelude_path);
-  loot_handle->GetDatabase().LoadUserlist(user_list_path);
+  if(!sfs::exists(user_list_path))
+    loot_handle->GetDatabase().LoadUserlist(user_list_path);
   if(progress_node)
     (*progress_node)->child(1).advance();
 

--- a/src/core/lootdeployer.cpp
+++ b/src/core/lootdeployer.cpp
@@ -186,7 +186,8 @@ void LootDeployer::sortModsByConflicts(std::optional<ProgressNode*> progress_nod
   sfs::path prelude_path(dest_path_ / "prelude.yaml");
   if(!sfs::exists(prelude_path))
     prelude_path = "";
-  loot_handle->GetDatabase().LoadLists(master_list_path, user_list_path, prelude_path);
+  loot_handle->GetDatabase().LoadMasterlistWithPrelude(master_list_path, prelude_path);
+  loot_handle->GetDatabase().LoadUserlist(user_list_path);
   if(progress_node)
     (*progress_node)->child(1).advance();
 


### PR DESCRIPTION
Fix for #190 