### PR TITLE
Support adding singular, non-archive files

### DIFF
--- a/src/core/installer.cpp
+++ b/src/core/installer.cpp
@@ -12,6 +12,43 @@
 namespace sfs = std::filesystem;
 namespace pu = path_utils;
 
+bool Installer::sourceIsArchvie(const sfs::path& source_path)
+{
+    const auto archiveExtensions = {
+      ".zip",
+      ".rar",
+      ".7z",
+      ".tar.gz",
+      ".tar",
+      ".tar.xz",
+      ".gz",
+      ".xz",
+      ".bz2",
+      ".tar.bz2",
+      ".lz",
+      ".lz4",
+      ".lzma",
+      ".aar",
+      ".ace",
+      ".arc",
+      ".ark",
+      ".tgz",
+      ".tbz2",
+      ".tar.lz",
+      ".tlz",
+      ".txz",
+      ".tar.zst",
+      ".war"
+    };
+
+    const std::string file_name = source_path.c_str();
+    for(std::string ext : archiveExtensions){
+      if(file_name.ends_with(ext)){
+        return true;
+      }
+    }
+    return false;
+}
 
 void Installer::extract(const sfs::path& source_path,
                         const sfs::path& dest_path,
@@ -26,6 +63,16 @@ void Installer::extract(const sfs::path& source_path,
       sfs::rename(source_path, dest_path);
     else
       sfs::copy(source_path, dest_path, sfs::copy_options::recursive);
+    return;
+  }
+
+  // for singular, non-archive files, just create the temp directory and copy the file to it
+  if(!sourceIsArchvie(source_path)){
+    const std::string base_file_name = source_path.filename();
+    const std::filesystem::path new_dest = dest_path / base_file_name;
+
+    sfs::create_directories(dest_path);
+    sfs::copy(source_path, new_dest);
     return;
   }
 
@@ -219,6 +266,13 @@ std::vector<std::pair<sfs::path, bool>> Installer::getArchiveFileNames(const sfs
       file_names.emplace_back(pu::getRelativePath(dir_entry.path(), path), sfs::is_directory(path));
     return file_names;
   }
+
+  // for singular, non-archive files, return data without trying to extract it
+  if(!sourceIsArchvie(path)){
+    file_names.emplace_back(pu::getRelativePath(path, path.parent_path()), sfs::is_directory(path));
+    return file_names;
+  }
+
   struct archive* source;
   struct archive_entry* entry;
   source = archive_read_new();

--- a/src/core/installer.cpp
+++ b/src/core/installer.cpp
@@ -14,40 +14,19 @@ namespace pu = path_utils;
 
 bool Installer::sourceIsArchvie(const sfs::path& source_path)
 {
-    const auto archiveExtensions = {
-      ".zip",
-      ".rar",
-      ".7z",
-      ".tar.gz",
-      ".tar",
-      ".tar.xz",
-      ".gz",
-      ".xz",
-      ".bz2",
-      ".tar.bz2",
-      ".lz",
-      ".lz4",
-      ".lzma",
-      ".aar",
-      ".ace",
-      ".arc",
-      ".ark",
-      ".tgz",
-      ".tbz2",
-      ".tar.lz",
-      ".tlz",
-      ".txz",
-      ".tar.zst",
-      ".war"
-    };
+    struct archive* source;
+    source = archive_read_new();
+    archive_read_support_filter_all(source);
+    archive_read_support_format_all(source);
 
-    const std::string file_name = source_path.c_str();
-    for(std::string ext : archiveExtensions){
-      if(file_name.ends_with(ext)){
-        return true;
-      }
+    if(archive_read_open_filename(source, source_path.c_str(), 10240) != ARCHIVE_OK){
+        return false;
     }
-    return false;
+    if(archive_read_free(source) != ARCHIVE_OK){
+        return false;
+    }
+
+    return true;
 }
 
 void Installer::extract(const sfs::path& source_path,

--- a/src/core/installer.cpp
+++ b/src/core/installer.cpp
@@ -12,7 +12,7 @@
 namespace sfs = std::filesystem;
 namespace pu = path_utils;
 
-bool Installer::sourceIsArchvie(const sfs::path& source_path)
+bool Installer::sourceIsArchive(const sfs::path& source_path)
 {
     struct archive* source;
     source = archive_read_new();
@@ -46,7 +46,7 @@ void Installer::extract(const sfs::path& source_path,
   }
 
   // for singular, non-archive files, just create the temp directory and copy the file to it
-  if(!sourceIsArchvie(source_path)){
+  if(!sourceIsArchive(source_path)){
     const std::string base_file_name = source_path.filename();
     const std::filesystem::path new_dest = dest_path / base_file_name;
 
@@ -247,7 +247,7 @@ std::vector<std::pair<sfs::path, bool>> Installer::getArchiveFileNames(const sfs
   }
 
   // for singular, non-archive files, return data without trying to extract it
-  if(!sourceIsArchvie(path)){
+  if(!sourceIsArchive(path)){
     file_names.emplace_back(pu::getRelativePath(path, path.parent_path()), sfs::is_directory(path));
     return file_names;
   }

--- a/src/core/installer.h
+++ b/src/core/installer.h
@@ -63,6 +63,13 @@ public:
   inline static const std::vector<std::string> INSTALLER_TYPES{ SIMPLEINSTALLER, FOMODINSTALLER };
 
   /*!
+  * \brief Checks if the given path is a supported archive filetype
+  * \param source_path Path to the file.
+  * \return bool true if supported archive file, otherwise false
+  */
+  static bool sourceIsArchvie(const std::filesystem::path& source_path);
+
+  /*!
    * \brief Extracts the given archive to the given directory.
    * \param source Path to the archive.
    * \param destination Destination directory for extraction.

--- a/src/core/installer.h
+++ b/src/core/installer.h
@@ -67,7 +67,7 @@ public:
   * \param source_path Path to the file.
   * \return bool true if supported archive file, otherwise false
   */
-  static bool sourceIsArchvie(const std::filesystem::path& source_path);
+  static bool sourceIsArchive(const std::filesystem::path& source_path);
 
   /*!
    * \brief Extracts the given archive to the given directory.


### PR DESCRIPTION
This attempts to add support for adding individual files that are not compressed/archive files.
Some examples of where this is useful is adding a standalone `.esp` file for Bethesda games, adding `.pak` files for Starbound, `.mod` files for Crusader Kings games, and similar use-cases (basically, whenever you just need to have that single file dropped in the deploy path).

To accomplish this, I add a new function to installer.cpp, `sourceIsArchvie` which compares the provided mod path against some known archive extensions. If we don't recognize the extension and the path is not a directory, then the file is added without trying to extract it.