### PR TITLE
fix Skyrim VR loot deployer target path in steam app configs

### DIFF
--- a/steam_app_configs/611670.json
+++ b/steam_app_configs/611670.json
@@ -17,7 +17,7 @@
     {
       "type": "Loot Deployer",
       "name": "Plugins",
-      "target_dir": "$STEAM_PREFIX_PATH$/users/steamuser/Local Settings/Application Data/Skyrim Special Edition",
+      "target_dir": "$STEAM_PREFIX_PATH$/users/steamuser/Local Settings/Application Data/Skyrim VR",
       "deploy_mode": "hard link",
       "source_dir": "$STEAM_INSTALL_PATH$/Data"
     }


### PR DESCRIPTION
## Summary

fix Skyrim VR loot deployer target path in steam app configs

## Related issue

close #224

## How is this tested?

Tested locally by editing the config in my flatpak:

`/var/lib/flatpak/app/io.github.limo_app.limo/x86_64/stable/5223fe5cc548043fd683b006d88f99aed193ee42cc8aee92bc12bbe214a39187/files/share/limo/steam_app_configs/611670.json`

Plugin deployer is now automatically added when importing Skyrim VR from steam

<img width="1404" height="872" alt="image" src="https://github.com/user-attachments/assets/1d1fa526-8d62-47d6-8fec-71934d744428" />

<img width="1485" height="872" alt="image" src="https://github.com/user-attachments/assets/654dcf38-1d4b-4dd1-979f-6d8f4008d598" />

